### PR TITLE
include WORD_SIZE in tagfile content

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -4,7 +4,7 @@ vers = "1.5.0"
 
 tagfile = "installed_vers"
 target = "libblosc.$(Sys.dlext)"
-if !isfile(tagfile) || readchomp(tagfile) != vers
+if !isfile(tagfile) || readchomp(tagfile) != "$vers $WORD_SIZE"
     if OS_NAME == :Windows
         run(download_cmd("http://ab-initio.mit.edu/blosc/libblosc$WORD_SIZE-$vers.dll", target))
     elseif OS_NAME == :Darwin
@@ -26,5 +26,7 @@ if !isfile(tagfile) || readchomp(tagfile) != vers
             run(`gcc -shared -o ../../$target blosc.o blosclz.o shuffle.o`)
         end
     end
-    run(`echo $vers` |> tagfile)
+    open(tagfile, "w") do f
+        write(f, "$vers $WORD_SIZE")
+    end
 end


### PR DESCRIPTION
this allows switching between 32 and 64 bit Julia without having to manually delete installed_vers

also use write instead of shelling out to echo, which is nonportable (it works on Windows only because we bundle busybox with the name echo.exe, ref https://github.com/timholy/HDF5.jl/commit/d531c088bd9dd8343069e4242f7a13569054feae - I plan on making sure this keeps working, but it relies on a GPL dependency and does require extra work on our side to make possible. Julia can't shell out to .bat files or cmd builtins due to limitations of libuv)
