### PR TITLE
Add support for lz4 and lz4hc compressors

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The functions provided are:
 
 * `Blosc.set_num_threads(n=CPU_CORES)`: tells Blosc to use `n` threads (initially `1`).
 
-* `Blosc.compressors()`: returns an array of strings for the available compression algorithms.  (Currently, only the `blosclz` algorithm is included.)
+* `Blosc.compressors()`: returns an array of strings for the available compression algorithms.  (Currently, only the `blosclz`, `lz4`, and `lz4hc` algorithms are included.)
 
 * `Blosc.set_compressor(s::String)`: set the current compression algorithm
 

--- a/deps/make.blosc
+++ b/deps/make.blosc
@@ -19,6 +19,12 @@ OTHER_OBJ = bitshuffle-generic.o shuffle-generic.o shuffle.o blosclz.o blosc.o
 # Check whether the option -mavx2 is supported
 CHECK_AVX2 = $(shell if $(CC) $(CPPFLAGS) $(CFLAGS) -mavx2 -c -o shuffle-avx2.tmp shuffle-avx2.c; then echo 1; else echo 0; fi; rm -f shuffle-avx2.tmp)
 
+# include internal LZ4
+# there will only be one LZ4 dir
+LZ4_DIR = $(wildcard ../internal-complibs/lz4-*)
+OTHER_OBJ += $(LZ4_DIR)/lz4.o $(LZ4_DIR)/lz4hc.o
+CFLAGS += -DHAVE_LZ4 -I$(LZ4_DIR)
+
 ifeq ($(shell uname -m), x86_64)
 HAVE_AVX=$(CHECK_AVX2)
 HAVE_SSE=1
@@ -77,3 +83,9 @@ blosclz.o: blosclz.c
 
 blosc.o: blosc.c
 	$(CC) $(CPPFLAGS) $(CFLAGS) -c -o $@ blosc.c
+
+$(LZ4_DIR)/lz4.o: $(LZ4_DIR)/lz4.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) -c -o $@ $(LZ4_DIR)/lz4.c
+
+$(LZ4_DIR)/lz4hc.o: $(LZ4_DIR)/lz4hc.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) -c -o $@ $(LZ4_DIR)/lz4hc.c

--- a/src/Blosc.jl
+++ b/src/Blosc.jl
@@ -148,7 +148,7 @@ end
 # If this function is not called, "blosclz" will be used.
 # Throws an ArgumentError if the given compressor is not supported
 function set_compressor(s::AbstractString)
-    compcode = ccall((:blosc_set_compressor,libblosc), Cint, (Ptr{UInt8},), s)
+    compcode = ccall((:blosc_set_compressor,libblosc), Cint, (Cstring,), s)
     compcode == -1 && throw(ArgumentError("unrecognized compressor $s"))
     return compcode
 end


### PR DESCRIPTION
Only adds the LZ4 libraries, not any other compressors.

Also changed a `Ptr{UInt8}` to `Cstring` in order to support passing `SubString` compressor names (something the tests do; without this change the tests would fail if there were more than just the "blosclz" compressor). 

Is there a process for compiling and uploading a new `.dll` and `.dylib`? Might we also consider compiling by default on macOS?