### PR TITLE
Better support for upstream snappy version

### DIFF
--- a/src/Blosc.jl
+++ b/src/Blosc.jl
@@ -290,7 +290,7 @@ function compressor_info(name::AbstractString)
     ret < 0 && error("Error retrieving compressor info for $name")
     lib_str = take_cstring(lib[])
     ver_str = take_cstring(ver[])
-    return (name, lib_str, convert(VersionNumber, ver_str))
+    return (name, lib_str, ver_str == "unknown" ? v"0.0.0" : convert(VersionNumber, ver_str))
 end
 
 """


### PR DESCRIPTION
This can happen if the blosc build picks up the vanilla version of snappy since it doesn't define the version macros....... Probably only happen in fairly non-standard setup but I think this shouldn't hurt.
