### PR TITLE
use c-blosc 1.12.1

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,6 +1,6 @@
 using BinDeps
 
-vers = "1.11.1"
+vers = "1.12.1"
 
 tagfile = "installed_vers"
 target = "libblosc.$(Libdl.dlext)"


### PR DESCRIPTION
Closes #41.

I've uploaded the new Win and Mac binaries to bintray, so hopefully we can merge this once tests are green.