### PR TITLE
use src.tar.gz for all tarballs so that new versions overwrite old

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -54,7 +54,7 @@ if unsatisfied || forcecompile
     # so that it is not overwritten by BinaryBuilder downloads or vice-versa.
     libname = "libblosc_from_source"
     products = [ LibraryProduct(prefix, [libname], :libblosc) ]
-    source_path = joinpath(prefix, "downloads", basename(source_url))
+    source_path = joinpath(prefix, "downloads", "src.tar.gz")
     if !isfile(source_path) || !verify(source_path, source_hash; verbose=verbose) || !satisfied(products[1]; verbose=verbose)
         compile(libname, source_url, source_hash, prefix=prefix, verbose=verbose)
     end

--- a/deps/compile.jl
+++ b/deps/compile.jl
@@ -4,7 +4,7 @@ using Compat.Libdl: dlext
 
 function compile(libname, tarball_url, hash; prefix=BinaryProvider.global_prefix, verbose=false)
     # download to tarball_path
-    tarball_path = joinpath(prefix, "downloads", basename(tarball_url))
+    tarball_path = joinpath(prefix, "downloads", "src.tar.gz")
     download_verify(tarball_url, hash, tarball_path; force=true, verbose=verbose)
 
     # unpack into source_path


### PR DESCRIPTION
Otherwise, after a while you will have a bunch of old tarballs lying around on machines that require source builds.