### PR TITLE
fix Libdl loading

### DIFF
--- a/src/Blosc.jl
+++ b/src/Blosc.jl
@@ -2,6 +2,7 @@ __precompile__()
 
 module Blosc
 using Compat
+using Compat.Libdl
 export compress, compress!, decompress, decompress!
 
 # Load blosc libraries from our deps.jl


### PR DESCRIPTION
This suppresses ``WARNING: Base.Libdl is deprecated, run `using Libdl` instead`` warnings.