### PR TITLE
v0.7 support: add `using Compat.Libdl` to Blosc.jl for deps.jl

### DIFF
--- a/src/Blosc.jl
+++ b/src/Blosc.jl
@@ -1,7 +1,7 @@
 __precompile__()
 
 module Blosc
-using Compat
+using Compat, Compat.Libdl
 export compress, compress!, decompress, decompress!
 
 # Load blosc libraries from our deps.jl

--- a/src/Blosc.jl
+++ b/src/Blosc.jl
@@ -1,7 +1,8 @@
 __precompile__()
 
 module Blosc
-using Compat, Compat.Libdl
+using Compat
+import Compat.Libdl
 export compress, compress!, decompress, decompress!
 
 # Load blosc libraries from our deps.jl


### PR DESCRIPTION
`deps.jl` uses `Libdl.dlopen_e` and is included in `Blosc.jl` so we need `Compat.Libdl`.