### PR TITLE
Expose c-blosc's bitshuffle capability (fix #87)

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -49,7 +49,7 @@ end
 for (comp, name, _) in Blosc.compressors_info()
     Blosc.set_compressor(comp)
     for level=0:9
-        for shuffle in (true, false)
+        for shuffle in (Blosc.NOSHUFFLE, Blosc.SHUFFLE, Blosc.BITSHUFFLE, true, false)
             for i=1:2048
                 a = rand(UInt8, i)
                 ac = Blosc.compress(a, level=level, shuffle=shuffle)


### PR DESCRIPTION
Shuffling is now a choice between no shuffling, byte shuffling, or bit
shuffling.  This changes the type of the `shuffle` keyword in `compress`
from `Bool` to its supertype `Integer`.  The previous "no shuffling"
(`shuffle=false`) and "byte shuffling" (`shuffle=true`) options map
cleanly onto the `Integer` assignments used by the Blosc library.  These
constants have been added to the Blosc module:

- `NOSHUFFLE` (0) means do no shuffling (same as the old `false`)
- `SHUFFLE` (1) means do byte shuffling (same as the old `true`)
- `BITSHUFFLE` (1) means do bit shuffling (not previously supported)

The `shuffled` field in `CompressionInfo` has also been widened to
`Integer` to allow it to properly reflect all types of shuffling and the
`compressor_info` function properly decodes the flags to set the
`shuffled` field appropriately.

The tests have been updated to exercise all three shuffle modes.